### PR TITLE
Adjust CONDA activate path call

### DIFF
--- a/src/main/java/qupath/ext/biop/cmd/VirtualEnvironmentRunner.java
+++ b/src/main/java/qupath/ext/biop/cmd/VirtualEnvironmentRunner.java
@@ -79,16 +79,21 @@ public class VirtualEnvironmentRunner {
 
         Platform platform = Platform.getCurrent();
         List<String> cmd = new ArrayList<>();
+        String cond_path;
 
         switch (envType) {
             case CONDA:
                 switch (platform) {
                     case WINDOWS:
-                        cmd.addAll(Arrays.asList("CALL", "conda.bat", "activate", environmentNameOrPath, "&", "python"));
+                        // Adjust path to the folder with the env name
+                        cond_path = new File(environmentNameOrPath).getParent();
+                        cmd.addAll(Arrays.asList("CALL", "conda.bat", "activate", cond_path, "&", "python"));
                         break;
                     case UNIX:
                     case OSX:
-                        cmd.addAll(Arrays.asList("conda", "activate", environmentNameOrPath, ";", "python"));
+                        // Adjust path to the folder with the env name
+                        cond_path = new File(environmentNameOrPath).getParentFile().getParent();
+                        cmd.addAll(Arrays.asList("conda", "activate", cond_path, ";", "python"));
                         break;
                 }
                 break;


### PR DESCRIPTION
Hi @lacan 

`conda activate` takes the path to the 'env-name' folder, rather than the python.exe (or python file).
I adjusted your `VirtualEnvironmentRunner` to use the parent of the python.exe.

For me, CONDA works on Windows, while on OSX, in the shell QuPath uses, `conda activate` does not work.

FYI:
The EXE generally works fine (also with conda environments). However, on Windows I experienced, that it would "skip the GPU initialisation" with my TensorFlow environment, and use the CPU instead. This seems to be due to Windows environment variables (pointing to the environment cuda dlls) missing.
With the `VirtualEnvironmentRunner.EnvType.CONDA` uses the GPU. Hence, I would be grateful for implementing those changes in your next release.
Thank you!