### PR TITLE
Ensure that operations are the same when processing multiple images

### DIFF
--- a/src/main/java/qupath/ext/biop/cellpose/Cellpose2D.java
+++ b/src/main/java/qupath/ext/biop/cellpose/Cellpose2D.java
@@ -1274,9 +1274,9 @@ public class Cellpose2D {
                     if (fullPreprocess.size() > 1)
                         fullPreprocess.add(ImageOps.Core.ensureType(PixelType.FLOAT32));
 
-                    op = op.appendOps(fullPreprocess.toArray(ImageOp[]::new));
+                    var opWithPreprocessing = op.appendOps(fullPreprocess.toArray(ImageOp[]::new));
 
-                    ImageServer<BufferedImage> processed = ImageOps.buildServer(imageData, op, resolution, tileWidth, tileHeight);
+                    ImageServer<BufferedImage> processed = ImageOps.buildServer(imageData, opWithPreprocessing, resolution, tileWidth, tileHeight);
 
                     LabeledImageServer labelServer = new LabeledImageServer.Builder(imageData)
                             .backgroundLabel(0, ColorTools.BLACK)


### PR DESCRIPTION
When using annotations from multiple brightfield images to train a model the operations are accumulating for every image, which lead in my case to an "unable to write image" error. Not mutating `op` fixes this.