### PR TITLE
Parallelise candidate object stream

### DIFF
--- a/src/main/java/qupath/ext/biop/cellpose/Cellpose2D.java
+++ b/src/main/java/qupath/ext/biop/cellpose/Cellpose2D.java
@@ -446,7 +446,7 @@ public class Cellpose2D {
 
             // Convert to detections, dilating to approximate cells if necessary
             // Drop cells if they fail (rather than catastrophically give up)
-            List<PathObject> finalObjects = filteredDetections.stream()
+            List<PathObject> finalObjects = filteredDetections.parallelStream()
                     .map(n -> {
                         try {
                             return convertToObject(n, parent.getROI().getImagePlane(), expansion, constrainToParent ? mask : null);


### PR DESCRIPTION
Dear @NicoKiaru, dear BIOP team

I have been running in a bottleneck, where loading/validating (many) candidate objects would take the majority of the extension run.

By simply using a `parallelStream()` instead of the "normal" `stream()`, the processing time can be greatly reduced.

For example processing a histology image (~63000x62000 pixels) would take **9h 36min**, resulting in ~790'000 cell objects, while cellpose segmentation itself takes <20min (on my PC).

With the suggested modification the whole processing time is reduced to **1h 6min**, resulting in the same number of cell objects.

I would be very happy to see this PR merged for a future release.

Thanks for continuing to develop this amazing extension!

Cheers,
Loïc