### PR TITLE
Allow using up to 3 channels when using cpsam

### DIFF
--- a/src/main/java/qupath/ext/biop/cellpose/CellposeBuilder.java
+++ b/src/main/java/qupath/ext/biop/cellpose/CellposeBuilder.java
@@ -875,8 +875,8 @@ public class CellposeBuilder {
         cellpose.extendChannelOp = this.extendChannelOp;
 
         // TODO make compatible with --all_channels
-        // FIXME here --> try to make 3 channel images for cpsam! --> check also if the memory usage can be cleared somehow
         if (this.channels.length > 2) {
+            // Allow up to 3 channels when using cpsam
             if (this.useCellposeSAM) {
                 if (this.channels.length > 3) {
                     logger.warn("You supplied {} channels, but cellposeSAM takes three channels at most. Keeping the first three.", this.channels.length);
@@ -884,6 +884,7 @@ public class CellposeBuilder {
                 else logger.warn("Using cpSAM with 3 channels.");
                 this.channels = Arrays.copyOf(this.channels, 3);
             }
+            // allow only 2 channels for cellpose <= 3 (no cpsam)
             else {
                 logger.warn("You supplied {} channels, but Cellpose needs two channels at most. Keeping the first two", this.channels.length);
                 this.channels = Arrays.copyOf(this.channels, 2);


### PR DESCRIPTION
Hi @Rdornier and BIOP team

Slightly late for the release that just happened.

When specifying channels to be used for cellpose, a maximum of 2 could be used.

This (minor) PR would allow to use up to 3 channels when using cpsam, in any desired channel order.

Minor because specifying no channel input will send all available channels, and cpsam will take the first 3.

I hope this makes sense.

Again, thanks a lot!
Cheers
